### PR TITLE
Add dynamic case studies pages

### DIFF
--- a/include/admin/views/board/template/casestudies/edit.php
+++ b/include/admin/views/board/template/casestudies/edit.php
@@ -99,6 +99,30 @@
 								<input type="text" class="form-control" name="subject" placeholder="제목" value="<?=$rs[0]['subject']?>" />
 							</div>
 						</div>
+<div class="form-group">
+    <label class="col-md-3 control-label">Technology</label>
+    <div class="col-md-9">
+        <input type="text" class="form-control" name="tmp1" placeholder="Technology" value="<?=$rs[0]['tmp1']?>" />
+    </div>
+</div>
+<div class="form-group">
+    <label class="col-md-3 control-label">Market</label>
+    <div class="col-md-9">
+        <input type="text" class="form-control" name="tmp2" placeholder="Market" value="<?=$rs[0]['tmp2']?>" />
+    </div>
+</div>
+<div class="form-group">
+    <label class="col-md-3 control-label">Project</label>
+    <div class="col-md-9">
+        <input type="text" class="form-control" name="tmp3" placeholder="Project" value="<?=$rs[0]['tmp3']?>" />
+    </div>
+</div>
+<div class="form-group">
+    <label class="col-md-3 control-label">Result</label>
+    <div class="col-md-9">
+        <input type="text" class="form-control" name="tmp4" placeholder="Result" value="<?=$rs[0]['tmp4']?>" />
+    </div>
+</div>
 						<? for($i = 0; $i < 1; $i++){ ?>
 							<div class="form-group isMultiFileGroup">
 								<label class="col-md-3 control-label">

--- a/include_sg/page/results/casestudies.php
+++ b/include_sg/page/results/casestudies.php
@@ -1,326 +1,88 @@
-<? $cfg['page_code'] = "results/casestudies"; ?>
-<? include_once __DIR__."/../../header.php"; ?>
-	<div class="sub_content_wrap">
-		<div class="sub_content_box">
-			<div class="sub_box">
-				<div class="sub_loc">
-					<div class="location">
-						<span>HOME</span>
-						<i></i>
-						<span>RESULTS</span>
-						<i></i>
-						<span>CASE STUDIES</span>
-					</div>
-				</div>
+<?php
+    $cfg['page_code'] = "results/casestudies";
+    include_once __DIR__."/../../lib/common.php";
 
-				<p class="sub_title ty02">Case Studies</p>
+    $boardName = "casestudies_en";
+    $tableName = $cfg['db']['prefix']."board_".$boardName;
+    $fileTableName = $cfg['db']['prefix']."boardFile";
+    $pageDir = "/results/casestudies/";
 
-				<div class="sub_text results_sub01">
-					<div class="contents_con">					
-						<div class="txt_con">
-							<div class="text01_con">
-								<span>
-									Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-								</span>
-							</div>
-						</div>
-
-						<div class="list_con">
-							<ul>
-								<li>
-									<a href="/results/casestudies_view">
-										<div class="list_div">
-											<div class="title_con">
-												<span>
-													제목영역입니다 내용을 입력해주세요
-												</span>
-											</div>
-
-											<div class="img_con">
-												<img src="/include_sg/images/sub/results_sub01_list_con_img_con_logo.png" alt="로고" >
-											</div>
-
-											<div class="list_con">
-												<ul>
-													<li>
-														<div class="list_div">
-															<div class="img_con">
-																<img src="/include_sg/images/sub/results_sub01_list_con_list_con_icon01.svg" alt="아이콘" >
-															</div>
-
-															<div class="text01_con">
-																<span>
-																	<span class="color_text">기술 :</span> 설명영역입니다 내용을 입력해주세요
-																</span>
-															</div>
-														</div>
-													</li>
-													<li>
-														<div class="list_div">
-															<div class="img_con">
-																<img src="/include_sg/images/sub/results_sub01_list_con_list_con_icon02.svg" alt="아이콘" >
-															</div>
-
-															<div class="text01_con">
-																<span>
-																	<span class="color_text">시장 :</span> 설명영역입니다 내용을 입력해주세요
-																</span>
-															</div>
-														</div>
-													</li>
-													<li>
-														<div class="list_div">
-															<div class="img_con">
-																<img src="/include_sg/images/sub/results_sub01_list_con_list_con_icon03.svg" alt="아이콘" >
-															</div>
-
-															<div class="text01_con">
-																<span>
-																	<span class="color_text">프로젝트 :</span> 설명영역입니다 내용을 입력해주세요
-																</span>
-															</div>
-														</div>
-													</li>
-													<li>
-														<div class="list_div">
-															<div class="img_con">
-																<img src="/include_sg/images/sub/results_sub01_list_con_list_con_icon04.svg" alt="아이콘" >
-															</div>
-
-															<div class="text01_con">
-																<span>
-																	<span class="color_text">성과 :</span> 설명영역입니다 내용을 입력해주세요
-																</span>
-															</div>
-														</div>
-													</li>
-												</ul>
-											</div>
-										</div>
-									</a>
-								</li>
-								<li>
-									<a href="">
-										<div class="list_div">
-											<div class="title_con">
-												<span>
-													제목영역입니다 내용을 입력해주세요
-												</span>
-											</div>
-
-											<div class="img_con">
-												<img src="/include_sg/images/sub/results_sub01_list_con_img_con_logo.png" alt="로고" >
-											</div>
-
-											<div class="list_con">
-												<ul>
-													<li>
-														<div class="list_div">
-															<div class="img_con">
-																<img src="/include_sg/images/sub/results_sub01_list_con_list_con_icon01.svg" alt="아이콘" >
-															</div>
-
-															<div class="text01_con">
-																<span>
-																	<span class="color_text">기술 :</span> 설명영역입니다 내용을 입력해주세요
-																</span>
-															</div>
-														</div>
-													</li>
-													<li>
-														<div class="list_div">
-															<div class="img_con">
-																<img src="/include_sg/images/sub/results_sub01_list_con_list_con_icon02.svg" alt="아이콘" >
-															</div>
-
-															<div class="text01_con">
-																<span>
-																	<span class="color_text">시장 :</span> 설명영역입니다 내용을 입력해주세요
-																</span>
-															</div>
-														</div>
-													</li>
-													<li>
-														<div class="list_div">
-															<div class="img_con">
-																<img src="/include_sg/images/sub/results_sub01_list_con_list_con_icon03.svg" alt="아이콘" >
-															</div>
-
-															<div class="text01_con">
-																<span>
-																	<span class="color_text">프로젝트 :</span> 설명영역입니다 내용을 입력해주세요
-																</span>
-															</div>
-														</div>
-													</li>
-													<li>
-														<div class="list_div">
-															<div class="img_con">
-																<img src="/include_sg/images/sub/results_sub01_list_con_list_con_icon04.svg" alt="아이콘" >
-															</div>
-
-															<div class="text01_con">
-																<span>
-																	<span class="color_text">성과 :</span> 설명영역입니다 내용을 입력해주세요
-																</span>
-															</div>
-														</div>
-													</li>
-												</ul>
-											</div>
-										</div>
-									</a>
-								</li>
-								<li>
-									<a href="">
-										<div class="list_div">
-											<div class="title_con">
-												<span>
-													제목영역입니다 내용을 입력해주세요
-												</span>
-											</div>
-
-											<div class="img_con">
-												<img src="/include_sg/images/sub/results_sub01_list_con_img_con_logo.png" alt="로고" >
-											</div>
-
-											<div class="list_con">
-												<ul>
-													<li>
-														<div class="list_div">
-															<div class="img_con">
-																<img src="/include_sg/images/sub/results_sub01_list_con_list_con_icon01.svg" alt="아이콘" >
-															</div>
-
-															<div class="text01_con">
-																<span>
-																	<span class="color_text">기술 :</span> 설명영역입니다 내용을 입력해주세요
-																</span>
-															</div>
-														</div>
-													</li>
-													<li>
-														<div class="list_div">
-															<div class="img_con">
-																<img src="/include_sg/images/sub/results_sub01_list_con_list_con_icon02.svg" alt="아이콘" >
-															</div>
-
-															<div class="text01_con">
-																<span>
-																	<span class="color_text">시장 :</span> 설명영역입니다 내용을 입력해주세요
-																</span>
-															</div>
-														</div>
-													</li>
-													<li>
-														<div class="list_div">
-															<div class="img_con">
-																<img src="/include_sg/images/sub/results_sub01_list_con_list_con_icon03.svg" alt="아이콘" >
-															</div>
-
-															<div class="text01_con">
-																<span>
-																	<span class="color_text">프로젝트 :</span> 설명영역입니다 내용을 입력해주세요
-																</span>
-															</div>
-														</div>
-													</li>
-													<li>
-														<div class="list_div">
-															<div class="img_con">
-																<img src="/include_sg/images/sub/results_sub01_list_con_list_con_icon04.svg" alt="아이콘" >
-															</div>
-
-															<div class="text01_con">
-																<span>
-																	<span class="color_text">성과 :</span> 설명영역입니다 내용을 입력해주세요
-																</span>
-															</div>
-														</div>
-													</li>
-												</ul>
-											</div>
-										</div>
-									</a>
-								</li>
-								<li>
-									<a href="">
-										<div class="list_div">
-											<div class="title_con">
-												<span>
-													제목영역입니다 내용을 입력해주세요
-												</span>
-											</div>
-
-											<div class="img_con">
-												<img src="/include_sg/images/sub/results_sub01_list_con_img_con_logo.png" alt="로고" >
-											</div>
-
-											<div class="list_con">
-												<ul>
-													<li>
-														<div class="list_div">
-															<div class="img_con">
-																<img src="/include_sg/images/sub/results_sub01_list_con_list_con_icon01.svg" alt="아이콘" >
-															</div>
-
-															<div class="text01_con">
-																<span>
-																	<span class="color_text">기술 :</span> 설명영역입니다 내용을 입력해주세요
-																</span>
-															</div>
-														</div>
-													</li>
-													<li>
-														<div class="list_div">
-															<div class="img_con">
-																<img src="/include_sg/images/sub/results_sub01_list_con_list_con_icon02.svg" alt="아이콘" >
-															</div>
-
-															<div class="text01_con">
-																<span>
-																	<span class="color_text">시장 :</span> 설명영역입니다 내용을 입력해주세요
-																</span>
-															</div>
-														</div>
-													</li>
-													<li>
-														<div class="list_div">
-															<div class="img_con">
-																<img src="/include_sg/images/sub/results_sub01_list_con_list_con_icon03.svg" alt="아이콘" >
-															</div>
-
-															<div class="text01_con">
-																<span>
-																	<span class="color_text">프로젝트 :</span> 설명영역입니다 내용을 입력해주세요 
-																</span>
-															</div>
-														</div>
-													</li>
-													<li>
-														<div class="list_div">
-															<div class="img_con">
-																<img src="/include_sg/images/sub/results_sub01_list_con_list_con_icon04.svg" alt="아이콘" >
-															</div>
-
-															<div class="text01_con">
-																<span>
-																	<span class="color_text">성과 :</span> 설명영역입니다 내용을 입력해주세요
-																</span>
-															</div>
-														</div>
-													</li>
-												</ul>
-											</div>
-										</div>
-									</a>
-								</li>
-							</ul>
-						</div>
-					</div>
-				</div>	<!--   sub_text end   -->
-			</div> <!--    sub_box end   -->
-		</div><!--   sub_content_box end   -->
-	</div><!--  sub_content_wrap end   -->
-
-<? include_once __DIR__."/../../footer.php"; ?>
+    $boardCoreOnly = true;
+    include_once __DIR__."/../board/board.core.php";
+    include_once __DIR__."/../../header.php";
+?>
+<div class="sub_content_wrap">
+    <div class="sub_content_box">
+        <div class="sub_box">
+            <div class="sub_loc">
+                <div class="location">
+                    <span>HOME</span>
+                    <i></i>
+                    <span>RESULTS</span>
+                    <i></i>
+                    <span>CASE STUDIES</span>
+                </div>
+            </div>
+            <p class="sub_title ty02">Case Studies</p>
+            <div class="sub_text results_sub01">
+                <div class="contents_con">
+                    <div class="txt_con">
+                        <div class="text01_con">
+                            <span>
+                                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                            </span>
+                        </div>
+                    </div>
+                    <div class="list_con">
+                        <ul>
+<?php foreach($rs as $row){ ?>
+                            <li>
+                                <a href="<?=$pageDir?>?v=<?=$row['no']?>">
+                                    <div class="list_div">
+                                        <div class="title_con">
+                                            <span><?=$row['subject']?></span>
+                                        </div>
+                                        <div class="img_con">
+                                            <img src="<?=$row['files'][0]['originalSrc']?>" alt="logo" >
+                                        </div>
+                                        <div class="list_con">
+                                            <ul>
+                                                <li>
+                                                    <div class="list_div">
+                                                        <div class="img_con"><img src="/include_sg/images/sub/results_sub01_list_con_list_con_icon01.svg" alt="icon" ></div>
+                                                        <div class="text01_con"><span><span class="color_text">Technology :</span> <?=$row['tmp1']?></span></div>
+                                                    </div>
+                                                </li>
+                                                <li>
+                                                    <div class="list_div">
+                                                        <div class="img_con"><img src="/include_sg/images/sub/results_sub01_list_con_list_con_icon02.svg" alt="icon" ></div>
+                                                        <div class="text01_con"><span><span class="color_text">Market :</span> <?=$row['tmp2']?></span></div>
+                                                    </div>
+                                                </li>
+                                                <li>
+                                                    <div class="list_div">
+                                                        <div class="img_con"><img src="/include_sg/images/sub/results_sub01_list_con_list_con_icon03.svg" alt="icon" ></div>
+                                                        <div class="text01_con"><span><span class="color_text">Project :</span> <?=$row['tmp3']?></span></div>
+                                                    </div>
+                                                </li>
+                                                <li>
+                                                    <div class="list_div">
+                                                        <div class="img_con"><img src="/include_sg/images/sub/results_sub01_list_con_list_con_icon04.svg" alt="icon" ></div>
+                                                        <div class="text01_con"><span><span class="color_text">Result :</span> <?=$row['tmp4']?></span></div>
+                                                    </div>
+                                                </li>
+                                            </ul>
+                                        </div>
+                                    </div>
+                                </a>
+                            </li>
+<?php } ?>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<?php include_once __DIR__."/../board/board.paginate.php"; ?>
+<?php include_once __DIR__."/../../footer.php"; ?>

--- a/include_sg/page/results/casestudies_view.php
+++ b/include_sg/page/results/casestudies_view.php
@@ -1,95 +1,71 @@
-<? $cfg['page_code'] = "results/casestudies_view"; ?>
-<? include_once __DIR__."/../../header.php"; ?>
-	<div class="sub_content_wrap">
-		<div class="sub_content_box">
-			<div class="sub_box">
-				<div class="sub_loc">
-					<div class="location">
-						<span>HOME</span>
-						<i></i>
-						<span>RESULTS</span>
-						<i></i>
-						<span>CASESTUDIES</span>
-					</div>
-				</div>
+<?php
+    $cfg['page_code'] = "results/casestudies_view";
+    include_once __DIR__."/../../lib/common.php";
 
-				<p class="sub_title ty02">Case Studies</p>
+    $boardName = "casestudies_en";
+    $tableName = $cfg['db']['prefix']."board_".$boardName;
+    $fileTableName = $cfg['db']['prefix']."boardFile";
+    $pageDir = "/results/casestudies/";
 
-				<div class="sub_text results_sub01_view">
-					<div class="contents_con">					
-						<div class="title_txt">
-							<div class="title_con">
-								<span>
-									제목영역입니다 내용을 입력해주세요
-								</span>
-							</div>
-
-							<div class="info_con">
-								<ul>
-									<li>
-										<div class="list_div">
-											<div class="writer_con">
-												<span>
-													피어슨파트너스
-												</span>
-											</div>
-										</div>
-									</li>
-									<li>
-										<div class="list_div">
-											<div class="text01_con">
-												<span>
-													Date
-												</span>
-											</div>
-
-											<div class="text02_con">
-												<span>
-													2025.01.10
-												</span>
-											</div>
-										</div>
-									</li>
-									<li>
-										<div class="list_div">
-											<div class="text01_con">
-												<span>
-													View
-												</span>
-											</div>
-
-											<div class="text02_con">
-												<span>
-													10
-												</span>
-											</div>
-										</div>
-									</li>
-								</ul>
-							</div>
-
-							<div class="file_con">
-								<a href="javascript:;">
-									첨부된 파일명.pdf
-								</a>
-							</div>
-						</div>
-
-						<div class="posts_con">
-							내용이 들어갑니다. 내용이 들어갑니다. 내용이 들어갑니다. <br>
-							내용이 들어갑니다. 내용이 들어갑니다. 
-						</div>
-
-						<div class="btn_con">
-							<a href="/results/casestudies/">
-								List
-							</a>
-						</div>
-					</div>
-				</div>	<!--   sub_text end   -->
-				
-			</div> <!--    sub_box end   -->
-		</div><!--   sub_content_box end   -->
-	</div><!--  sub_content_wrap end   -->
-
-<? include_once __DIR__."/../../footer.php"; ?>
+    $boardCoreOnly = true;
+    include_once __DIR__."/../board/board.core.php";
+    include_once __DIR__."/../../header.php";
+?>
+<div class="sub_content_wrap">
+    <div class="sub_content_box">
+        <div class="sub_box">
+            <div class="sub_loc">
+                <div class="location">
+                    <span>HOME</span>
+                    <i></i>
+                    <span>RESULTS</span>
+                    <i></i>
+                    <span>CASESTUDIES</span>
+                </div>
+            </div>
+            <p class="sub_title ty02">Case Studies</p>
+            <div class="sub_text results_sub01_view">
+                <div class="contents_con">
+                    <div class="title_txt">
+                        <div class="title_con">
+                            <span><?=$self['subject']?></span>
+                        </div>
+                        <div class="info_con">
+                            <ul>
+                                <li>
+                                    <div class="list_div">
+                                        <div class="writer_con"><span><?=$self['name']?></span></div>
+                                    </div>
+                                </li>
+                                <li>
+                                    <div class="list_div">
+                                        <div class="text01_con"><span>Date</span></div>
+                                        <div class="text02_con"><span><?=date('Y.m.d', strtotime($self['regDate']))?></span></div>
+                                    </div>
+                                </li>
+                                <li>
+                                    <div class="list_div">
+                                        <div class="text01_con"><span>View</span></div>
+                                        <div class="text02_con"><span><?=$self['hit']?></span></div>
+                                    </div>
+                                </li>
+                            </ul>
+                        </div>
+                        <?php if($self['files'][3]['realName']){ ?>
+                        <div class="file_con">
+                            <a href="<?=$cfg['href']?>/board/download.php?t=<?=$boardName?>&n=<?=$self['files'][3]['no']?>"><?=$self['files'][3]['realName']?></a>
+                        </div>
+                        <?php } ?>
+                    </div>
+                    <div class="posts_con">
+                        <?=$self['content']?>
+                    </div>
+                    <div class="btn_con">
+                        <a href="<?=$pageDir?>">List</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<?php include_once __DIR__."/../../footer.php"; ?>


### PR DESCRIPTION
## Summary
- 관리자 케이스 스터디 입력폼에 Technology, Market, Project, Result 항목을 추가
- 싱가포르 사이트 케이스 스터디 목록/상세 페이지를 DB 연동형으로 수정

## Testing
- `php` 명령을 사용할 수 없어서 구문 검사를 진행하지 못했습니다

------
https://chatgpt.com/codex/tasks/task_e_685cedce957c83229dc15af60a871590