### PR TITLE
Fix casestudies view hit count

### DIFF
--- a/include/admin/views/board/template/casestudies/list.php
+++ b/include/admin/views/board/template/casestudies/list.php
@@ -81,7 +81,7 @@
 									<td><?=$row['hit']?></td>
 									<td><?=$row['regDate']?></td>
 									<td>
-										<a href="board_edit.php?mode=update&no=<?=$row['no']?><?=$qstr?><?=$_GET['page']?>" class="btn btn-xs btn-info m-r-5">수정</a>
+                                                                       <a href="board_edit.php?board=<?=$_GET['board']?>&mode=update&no=<?=$row['no']?><?=$qstr?><?=$_GET['page']?>" class="btn btn-xs btn-info m-r-5">수정</a>
 										<? if($_SESSION['userLevel'] > 100){ ?>
 										<form action="board_process.php" method="post" style="display: inline;" class="delete-confirm">
 											<input type="hidden" name="board" value="<?=$_GET['board']?>" />

--- a/include_sg/page/results/casestudies_view.php
+++ b/include_sg/page/results/casestudies_view.php
@@ -9,6 +9,16 @@ $pageDir = "/results/casestudies/";
 
 $boardCoreOnly = true;
 include_once __DIR__ . "/../board/board.core.php";
+if ($_GET['v'] != "" || $_GET['pl'] != "") {
+    if ($_COOKIE[md5("cki_".$boardName."_".$self['no']."_hit")] != base64_encode($self['no'])) {
+        try {
+            Queryi("UPDATE $tableName SET hit = hit + 1 WHERE no = ?", array($self['no']));
+        } catch (PDOException $e) {
+            // do nothing on error
+        }
+        setcookie(md5("cki_".$boardName."_".$self['no']."_hit"), base64_encode($self['no']), time() + (86400 * 36500), "/", $_SERVER["SERVER_NAME"]);
+    }
+}
 include_once __DIR__ . "/../../header.php";
 ?>
 <div class="sub_content_wrap">


### PR DESCRIPTION
## Summary
- increment view count in casestudies view
- pass board parameter on admin list update link

## Testing
- `php -l include_sg/page/results/casestudies_view.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cfd54e57c8322b9b94e9b3d9ac965