### PR TITLE
Enable intro management for casestudies boards

### DIFF
--- a/include/admin/views/board/template/casestudies_en/list.php
+++ b/include/admin/views/board/template/casestudies_en/list.php
@@ -41,8 +41,14 @@
 					<div class="panel-heading-btn"></div>
 					<h4 class="panel-title">Showing <?=$fromLimit?> to <?=$pagingItemMax?> of <?=$dataCount?> entries</h4>
 				</div>
-				<div class="panel-body">
-					<div class="col-md-12 m-b-10 text-right p-l-0 p-r-0">
+                                <div class="panel-body">
+                                        <form action="board_process.php" method="post" class="m-b-15">
+                                                <input type="hidden" name="board" value="<?=$_GET['board']?>" />
+                                                <input type="hidden" name="mode" value="intro" />
+                                                <textarea name="intro" class="form-control" rows="4"><?=$introText?></textarea>
+                                                <div class="text-right m-t-5"><button type="submit" class="btn btn-xs btn-primary">Apply</button></div>
+                                        </form>
+                                        <div class="col-md-12 m-b-10 text-right p-l-0 p-r-0">
 						<form class="form-group" action="" method="GET">
 							<input type="hidden" name="board" value="<?=$_GET['board']?>">
 							<input type="text" class="form-control" name="search" placeholder="검색어" value="<?=$_GET['search']?>" />

--- a/include/admin/views/board/template/casestudies_kr/list.php
+++ b/include/admin/views/board/template/casestudies_kr/list.php
@@ -41,8 +41,14 @@
 					<div class="panel-heading-btn"></div>
 					<h4 class="panel-title">Showing <?=$fromLimit?> to <?=$pagingItemMax?> of <?=$dataCount?> entries</h4>
 				</div>
-				<div class="panel-body">
-					<div class="col-md-12 m-b-10 text-right p-l-0 p-r-0">
+                                <div class="panel-body">
+                                        <form action="board_process.php" method="post" class="m-b-15">
+                                                <input type="hidden" name="board" value="<?=$_GET['board']?>" />
+                                                <input type="hidden" name="mode" value="intro" />
+                                                <textarea name="intro" class="form-control" rows="4"><?=$introText?></textarea>
+                                                <div class="text-right m-t-5"><button type="submit" class="btn btn-xs btn-primary">적용</button></div>
+                                        </form>
+                                        <div class="col-md-12 m-b-10 text-right p-l-0 p-r-0">
 						<form class="form-group" action="" method="GET">
 							<input type="hidden" name="board" value="<?=$_GET['board']?>">
 							<input type="text" class="form-control" name="search" placeholder="검색어" value="<?=$_GET['search']?>" />

--- a/include_kr/page/results/casestudies.php
+++ b/include_kr/page/results/casestudies.php
@@ -9,6 +9,11 @@ $pageDir = "/results/casestudies/";
 
 $boardCoreOnly = true;
 include_once __DIR__ . "/../board/board.core.php";
+
+$introTableName = $cfg['db']['prefix'] . "board_intro";
+$introRow = Queryi("SELECT content FROM $introTableName WHERE board = ?", array($boardName), true);
+$introText = $introRow['content'];
+
 include_once __DIR__ . "/../../header.php";
 ?>
 <? include_once __DIR__ . "/../../header.php"; ?>
@@ -31,12 +36,7 @@ include_once __DIR__ . "/../../header.php";
                 <div class="contents_con">
                     <div class="txt_con">
                         <div class="text01_con">
-                            <span>
-                                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
-                                incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-                                exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
-                                dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-                            </span>
+                            <span><?=$introText?></span>
                         </div>
                     </div>
 

--- a/include_sg/page/results/casestudies.php
+++ b/include_sg/page/results/casestudies.php
@@ -9,6 +9,11 @@ $pageDir = "/results/casestudies/";
 
 $boardCoreOnly = true;
 include_once __DIR__ . "/../board/board.core.php";
+
+$introTableName = $cfg['db']['prefix'] . "board_intro";
+$introRow = Queryi("SELECT content FROM $introTableName WHERE board = ?", array($boardName), true);
+$introText = $introRow['content'];
+
 include_once __DIR__ . "/../../header.php";
 ?>
 <? include_once __DIR__ . "/../../header.php"; ?>
@@ -31,12 +36,7 @@ include_once __DIR__ . "/../../header.php";
                 <div class="contents_con">
                     <div class="txt_con">
                         <div class="text01_con">
-                            <span>
-                                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
-                                incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-                                exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
-                                dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-                            </span>
+                            <span><?=$introText?></span>
                         </div>
                     </div>
 

--- a/mobile/include_kr/page/results/casestudies.php
+++ b/mobile/include_kr/page/results/casestudies.php
@@ -9,6 +9,11 @@ $pageDir = "/results/casestudies/";
 
 $boardCoreOnly = true;
 include_once __DIR__ . "/../board/board.core.php";
+
+$introTableName = $cfg['db']['prefix'] . "board_intro";
+$introRow = Queryi("SELECT content FROM $introTableName WHERE board = ?", array($boardName), true);
+$introText = $introRow['content'];
+
 include_once __DIR__ . "/../../header.php";
 ?>
 <? include_once __DIR__ . "/../../header.php"; ?>
@@ -30,11 +35,9 @@ include_once __DIR__ . "/../../header.php";
 				<div class="sub_text results_sub01">
 					<div class="contents_con">					
 						<div class="txt_con">
-							<div class="text01_con">
-								<span>
-									Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-								</span>
-							</div>
+                                                        <div class="text01_con">
+                                                                <span><?=$introText?></span>
+                                                        </div>
 						</div>
 
 						<div class="list_con">

--- a/mobile/include_sg/page/results/casestudies.php
+++ b/mobile/include_sg/page/results/casestudies.php
@@ -9,6 +9,11 @@ $pageDir = "/results/casestudies/";
 
 $boardCoreOnly = true;
 include_once __DIR__ . "/../board/board.core.php";
+
+$introTableName = $cfg['db']['prefix'] . "board_intro";
+$introRow = Queryi("SELECT content FROM $introTableName WHERE board = ?", array($boardName), true);
+$introText = $introRow['content'];
+
 include_once __DIR__ . "/../../header.php";
 ?>
 <? include_once __DIR__ . "/../../header.php"; ?>
@@ -30,11 +35,9 @@ include_once __DIR__ . "/../../header.php";
 				<div class="sub_text results_sub01">
 					<div class="contents_con">					
 						<div class="txt_con">
-							<div class="text01_con">
-								<span>
-									Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-								</span>
-							</div>
+                                                        <div class="text01_con">
+                                                                <span><?=$introText?></span>
+                                                        </div>
 						</div>
 
 						<div class="list_con">


### PR DESCRIPTION
## Summary
- add intro editing form on casestudies_en/kr admin pages
- render intro text dynamically on casestudies front pages (desktop/mobile)

## Testing
- `php` binary not available, so no tests were run

------
https://chatgpt.com/codex/tasks/task_e_6861e2967254832298a43c291faad1a4